### PR TITLE
only wait for the JSON schema to generate if it has actually changed

### DIFF
--- a/.github/workflows/package_data.yml
+++ b/.github/workflows/package_data.yml
@@ -9,8 +9,14 @@ jobs:
   generate:
     runs-on: ubuntu-latest
     steps:
+      - uses: marceloprado/has-changed-path@v1.0.1
+        id: schema-changed
+        with:
+          paths: ./schemas
+
       - name: Wait for JSON schema to generate
         uses: lewagon/wait-on-check-action@v1.3.1
+        if: ${{ steps.schema-changed.outputs.changed }}
         with:
           ref: ${{ github.ref }}
           check-name: "Generate JSON Schemas"
@@ -34,7 +40,7 @@ jobs:
 
       - name: Validate generated file
         run: npx ajv-cli -s ./schemas/generated/data.json --errors=text -d ./raw/data.json
-      
+
       - name: Commit schemas
         uses: EndBug/add-and-commit@v9
         with:


### PR DESCRIPTION
this fixes (theoretically!) all the failing checks we've been seeing
