### PR TITLE
fix we1 ligature for fairfax pona (hd) and ssk

### DIFF
--- a/words/metadata/we1.toml
+++ b/words/metadata/we1.toml
@@ -23,7 +23,7 @@ word = "güey"
 word = "man"
 
 [representations]
-ligatures = ["we"]
+ligatures = ["we1"]
 sitelen_emosi = "🔒"
 
 [usage]


### PR DESCRIPTION
the current ligature is for the 😎 *we* rather than the `…` *we*. this pr fixes that